### PR TITLE
Update jimp

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/tooolbox/node-potrace#readme",
   "dependencies": {
-    "jimp": "^0.2.24"
+    "jimp": "^0.6.4"
   },
   "devDependencies": {
     "lodash": "^4.15.0",


### PR DESCRIPTION
Address #4

Updating `jimp` addresses the following vulnerability detected in a project depending on `node-potrace` https://nvd.nist.gov/vuln/detail/CVE-2018-1000620

<img width="522" alt="Screenshot 2019-06-18 at 21 11 52" src="https://user-images.githubusercontent.com/2437969/59712552-bcb94780-920d-11e9-8e2d-1bc222ef65eb.png">
