### PR TITLE
update github repo urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tooolbox/node-potrace.git"
+    "url": "git+https://github.com/Iwasawafag/node-potrace.git"
   },
   "keywords": [
     "potrace",
@@ -21,9 +21,9 @@
   "author": "mattmc",
   "license": "GPL-2.0",
   "bugs": {
-    "url": "https://github.com/tooolbox/node-potrace/issues"
+    "url": "https://github.com/Iwasawafag/node-potrace/issues"
   },
-  "homepage": "https://github.com/tooolbox/node-potrace#readme",
+  "homepage": "https://github.com/Iwasawafag/node-potrace#readme",
   "dependencies": {
     "jimp": "^0.6.4"
   },


### PR DESCRIPTION
Hey. When I first started to look into the license issue I thought npm still has the version from https://github.com/tooolbox/node-potrace because the link was pointing there and I saw this comment 

> I've also unpublished it from NPM...at least I tried.

https://github.com/Iwasawafag/node-potrace/pull/1

I thought it might be a good idea to update the urls to point to this repo instead. Since this repo is used in gatsby-plugin-sharp I guess it is widely used.