### PR TITLE
Upgrade Jimp to address minimist security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/tooolbox/node-potrace#readme",
   "dependencies": {
-    "jimp": "^0.6.4"
+    "jimp": ">=0.9.6 <1"
   },
   "devDependencies": {
     "lodash": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/tooolbox/node-potrace#readme",
   "dependencies": {
-    "jimp": ">=0.9.6 <1"
+    "jimp": "^0.9.6"
   },
   "devDependencies": {
     "lodash": "^4.15.0",


### PR DESCRIPTION
# Why was this closed?

This is not the correct repo!

<img src=https://user-images.githubusercontent.com/1935696/77850209-39337a80-71d1-11ea-9f68-d44f86276766.png alt="" width="300" />

Opened a new PR in the new maintained repo of `node-potrace` here: https://github.com/tooolbox/node-potrace/pull/5

This new repo is maintained by @tooolbox.

---

Since the pull request for Jimp addressing `minimist` security vulnerability (https://www.npmjs.com/advisories/1179) was accepted, it would be good to upgrade to at least `0.9.6`:

https://github.com/oliver-moran/jimp/pull/857

Original fix in `mkdirp`: https://github.com/isaacs/node-mkdirp/issues/7#issuecomment-600231795

It seems like the last minor releases have not changed anything breaking...?

- https://github.com/oliver-moran/jimp/releases/tag/v0.7.0
- https://github.com/oliver-moran/jimp/releases/tag/v0.8.0
- https://github.com/oliver-moran/jimp/releases/tag/v0.9.0

If this is accepted and released as a minor or patch, this will also enable Gatsby projects to fix the security issues without breaking semver, since `gatsby-plugin-sharp` and `gatsby-transformer-sharp` depend on `potrace@^2.1.2`:

- https://github.com/gatsbyjs/gatsby/blob/2ff2ba395a86407e3ccfd1e010be7408a4817a82/packages/gatsby-plugin-sharp/package.json#L22
- https://github.com/gatsbyjs/gatsby/blob/2ff2ba395a86407e3ccfd1e010be7408a4817a82/packages/gatsby-transformer-sharp/package.json#L13